### PR TITLE
Fix runtime.env path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To co-locate the Linux CF CLI BOSH job on your target VM, follow these steps:
 
 1. add the "cf-cli" BOSH release to your deployment manifest
 2. add the "cf-cli-6-linux" BOSH job on the VM you want to install the CF CLI binary on
-3. in one of your BOSH job scripts on the same VM, add the following bash command `source /var/vcap/jobs/cf-cli-6-linux/bin/bosh/runtime.env` before any command that calls the `cf` binary
+3. in one of your BOSH job scripts on the same VM, add the following bash command `source /var/vcap/packages/cf-cli-6-linux/bosh/runtime.env` before any command that calls the `cf` binary
 
 Behind the scenes, the CF CLI binary is installed on the target machine at compile time via the "cf-cli-6-linux" BOSH package (dependency of the "cf-cli-6-linux" BOSH job). Your BOSH job script runs the bash command to add the `cf` binary to PATH.
 


### PR DESCRIPTION
Fixes incorrect runtime.env path to `/var/vcap/packages/cf-cli-6-linux/bosh/runtime.env`.

https://github.com/bosh-packages/cf-cli-release/blob/835a187f5dc179daf32312d66dbd4718643150f5/jobs/cf-cli-6-linux/templates/runtime.env#L5